### PR TITLE
Correct the whitelist source header check

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ QuIC repos should enable the Repolinter GitHub Action upon creation. This action
 1. This will create a GitHub Action config file in your repo under the path `.github/workflows/quic-organization-repolinter.yml`
 1. Adjust it as needed, e.g. the Repolinter action is configured to run on Push and Pull Requests into the main/master branch, but you may want to further adjust when it runs.
 
-### Customizing Repolinter rules
+### Customize Repolinter Rules
 
 When the GitHub Action is run, it first checks your QuIC repo for a local `repolint.json` file at the root directory. If it doesn't find one it'll use the default QuIC Repolinter ruleset, which is located here https://github.com/quic/.github/blob/main/repolint.json
 
-To customize the default QuIC repolinter ruleset (e.g. to add some language specific file extensions for the license check), you can extend the default ruleset and override specific rules. 
+To customize the default QuIC Repolinter ruleset (e.g. to add some language specific file extensions for the license check), you can extend the default ruleset and override specific rules. In other cases you may have to copy the ruleset locally and edit as needed. See below for examples.
 
-For example, if we wanted to exclude the copyright/license check for a directory e.g. `/test-data` from Repolinter:
+#### Exclude directories or files from the source file header check
+
+For example, if we wanted to exclude the copyright/license check for a directory e.g. `/test-data` from Repolinter, we can extend the ruleset as we are adding additional rules.
 
 1. Create the file `repolint.json` at the root of your project
 1. "Extend" the QuIC repolint.json file
@@ -85,46 +87,36 @@ For example, if we wanted to exclude the copyright/license check for a directory
 }
 ```
 
-### Creating a Whitelist for Copyright/License Check in Repolinter
-* To include only specific directories (e.g., `/test1-data`, `/test2-data`) in the copyright/license check using Repolinter, follow these steps:
+#### Include only specific directories or files in the source file header check
 
-1. Create the file `repolint.json` at the root of your project
-2. "Extend" the QuIC repolint.json file
+For example, to only check `.c` files in a specific directory (e.g., `/src`) in the copyright/license check using Repolinter, we cannot extend and must instead replace the ruleset and edit it as necessary.
 
-```json
-{
-  "extends": "https://raw.githubusercontent.com/quic/.github/main/repolint.json",
-  "rules": {}
-}
-```
-
-3. Copy the rule block you need to adjust from `https://raw.githubusercontent.com/quic/.github/main/repolint.json`. E.g. in this case we want to include only `/test1-data`, `/test2-data` from the license header check. So let's copy the json block `source-license-headers-exist` and paste it into the `rules` section of the local `repolint.json` we extended.
-4. Adjust the rule to include only the (e.g. `/test1-data`, `/test2-data`) directories.
-   
-* Your repolint.json should look like this:
+1. Copy the default QuIC [repolint.json](https://raw.githubusercontent.com/quic/.github/main/repolint.json) ruleset to the root of your project
+2. Find the relevant rule to edit. In this example, we are going to edit the `source-license-headers-exist` rule and replace the `globsAll` property to only `.c` files in the `/src` directory.
 
 ```json
-{
-  "extends": "https://raw.githubusercontent.com/quic/.github/main/repolint.json",
-  "rules": {
+[...]
     "source-license-headers-exist": {
       "level": "error",
       "rule": {
         "type": "file-starts-with",
         "options": {
           "globsAll": [
-            "test1-data/**",
-            "test2-data/**"
+            "src/**/*.c"
           ],
+          "skip-paths-matching": {
+            "patterns": []
+          },
           "lineCount": 60,
           "patterns": [
             "(Copyright|©).*Qualcomm Innovation Center, Inc|Copyright (\\(c\\)|©) (20(1[2-9]|2[0-2])(-|,|\\s)*)+ The Linux Foundation",
             "SPDX-License-Identifier|Redistribution and use in source and binary forms, with or without"
           ],
-          "flags": "i",
-          "succeed-on-non-existent": true
+          "flags": "i"
         }
       }
-    }
-  }
-}
+    },
+[...]    
+```
+
+3. For more information on Repolinter rules and options, see [Repolinter rules](https://github.com/todogroup/repolinter/blob/main/docs/rules.md)


### PR DESCRIPTION
@quic-nwtn I tested your change and it didn't actually work as I anticipated. Apparently extending rulesets only works in cases where we add to the existing rules, as repolinter does a deep merge of the rules. So what was happening is that it was still checking all of these

```
         "globsAll": [
            "**/*.py",
            "**/*.js",
            "**/*.c",
            "**/*.cc",
            "**/*.cpp",
            "**/*.h",
            "**/*.ts",
            "**/*.sh",
            "**/*.rs",
            "**/*.java",
            "**/*.go",
            "**/*.bbclass",
            "**/*.S"
          ],
```

and then adding 

```
            "test1-data/**",
            "test2-data/**"
```

to that check. 

So to replace `globsAll` completely we need to replace the whole file. See the PR.

I think we could break out our repolint.json into multiple files as you can nest them. But we can look at this another time.

I also updated the example to `src/**/*.c` as it's more realistic. I.e. we don't want to check every file type in a directory, e.g. only `.c` in `src\`.