### PR TITLE
Extend copyright year check and allow external copyright owners

### DIFF
--- a/repolint.json
+++ b/repolint.json
@@ -166,7 +166,7 @@
           },
           "lineCount": 60,
           "patterns": [
-            "(Copyright|©).*Qualcomm Innovation Center, Inc|Copyright (\\(c\\)|©) (20(1[2-9]|2[0-2])(-|,|\\s)*)+ The Linux Foundation",
+            "Copyright (\\(c\\)|©)?",
             "SPDX-License-Identifier|Redistribution and use in source and binary forms, with or without"
           ],
           "flags": "i"

--- a/repolint.json
+++ b/repolint.json
@@ -173,6 +173,45 @@
         }
       }
     },
+    "source-qualcomm-license-headers-exist": {
+      "level": "warning",
+      "rule": {
+        "type": "file-starts-with",
+        "options": {
+          "globsAll": [
+            "**/*.py",
+            "**/*.js",
+            "**/*.c",
+            "**/*.cc",
+            "**/*.cpp",
+            "**/*.h",
+            "**/*.ts",
+            "**/*.sh",
+            "**/*.rs",
+            "**/*.java",
+            "**/*.go",
+            "**/*.bbclass",
+            "**/*.S",
+            "**/*.hpp"
+          ],
+          "skip-paths-matching": {
+            "patterns": [
+              "babel.config.js",
+              "build\/",
+              "jest.config.js",
+              "node_modules\/",
+              "types\/",
+              "uthash.h"
+            ]
+          },
+          "lineCount": 60,
+          "patterns": [
+            "(Copyright|©).*Qualcomm Innovation Center, Inc|Copyright (\\(c\\)|©) (20(1[2-9]|2[0-2])(-|,|\\s)*)+ The Linux Foundation"
+          ],
+          "flags": "i"
+        }
+      }
+    },
     "github-issue-template-exists": {
       "level": "warning",
       "rule": {


### PR DESCRIPTION
As we are opening up several repositories to accept contributions from
external developers, remove the check that enforces Copyright to be set
to Qualcomm or Linux Foundation only, as it can be assigned to other
companies and users.