### PR TITLE
repolint.json: remove bb-file-license-exist check

### DIFF
--- a/repolint.json
+++ b/repolint.json
@@ -173,22 +173,6 @@
         }
       }
     },
-    "bb-file-license-exist": {
-      "level": "error",
-      "rule": {
-        "type": "file-starts-with",
-        "options": {
-          "globsAll": [
-            "**/*.bb"
-          ],
-          "succeed-on-non-existent": true,
-          "lineCount": 40,
-          "patterns": [
-            "LICENSE\\s*="
-          ]
-        }
-      }
-    },
     "github-issue-template-exists": {
       "level": "warning",
       "rule": {


### PR DESCRIPTION
It is a common practice in OE/Yocto for recipes to include other files (e.g. .inc) that contains the LICENSE declaration (e.g. recipes for multiple versions of the same software component), so this check will quite often fail.

Since LICENSE is not the license of the bb file itself, but for the software the recipe is providing build instructions for, we can rely on OE to verify that there is a valid declaration instead of having it as part of repolinter.

Fixes #33.