### PR TITLE
Make space optional between copyright and copyright symbol

### DIFF
--- a/repolint.json
+++ b/repolint.json
@@ -166,7 +166,7 @@
           },
           "lineCount": 60,
           "patterns": [
-            "Copyright (\\(c\\)|©)?",
+            "Copyright(\\s)*(\\(c\\)|©)?",
             "SPDX-License-Identifier|Redistribution and use in source and binary forms, with or without"
           ],
           "flags": "i"


### PR DESCRIPTION
Resolves issue with Copyright(c) failing reported in #40 