### PR TITLE
Update copyright/license header checks

### DIFF
--- a/repolint-qcom.json
+++ b/repolint-qcom.json
@@ -1,0 +1,44 @@
+{
+    "extends": "https://raw.githubusercontent.com/quic/.github/main/repolint.json",
+    "rules": {
+        "qualcomm-source-license-headers-exist": {
+            "level": "error",
+            "rule": {
+              "type": "file-starts-with",
+              "options": {
+                "globsAll": [
+                  "**/*.py",
+                  "**/*.js",
+                  "**/*.c",
+                  "**/*.cc",
+                  "**/*.cpp",
+                  "**/*.h",
+                  "**/*.ts",
+                  "**/*.sh",
+                  "**/*.rs",
+                  "**/*.java",
+                  "**/*.go",
+                  "**/*.bbclass",
+                  "**/*.S",
+                  "**/*.hpp"
+                ],
+                "skip-paths-matching": {
+                  "patterns": [
+                    "babel.config.js",
+                    "build\/",
+                    "jest.config.js",
+                    "node_modules\/",
+                    "types\/",
+                    "uthash.h"
+                  ]
+                },
+                "lineCount": 60,
+                "patterns": [
+                  "(Copyright|©).*Qualcomm Innovation Center, Inc|Copyright (\\(c\\)|©) (20(1[2-9]|2[0-2])(-|,|\\s)*)+ The Linux Foundation"
+                ],
+                "flags": "i"
+              }
+            }
+          }        
+    }
+  }

--- a/repolint.json
+++ b/repolint.json
@@ -134,6 +134,45 @@
       }
     },
     "source-license-headers-exist": {
+      "level": "error",
+      "rule": {
+        "type": "file-starts-with",
+        "options": {
+          "globsAll": [
+            "**/*.py",
+            "**/*.js",
+            "**/*.c",
+            "**/*.cc",
+            "**/*.cpp",
+            "**/*.h",
+            "**/*.ts",
+            "**/*.rs",
+            "**/*.java",
+            "**/*.go",
+            "**/*.bbclass",
+            "**/*.S",
+            "**/*.hpp"
+          ],
+          "skip-paths-matching": {
+            "patterns": [
+              "babel.config.js",
+              "build\/",
+              "jest.config.js",
+              "node_modules\/",
+              "types\/",
+              "uthash.h"
+            ]
+          },
+          "lineCount": 60,
+          "patterns": [
+            "Copyright(\\s)*(\\(c\\)|©)?",
+            "SPDX-License-Identifier|Redistribution and use in source and binary forms, with or without"
+          ],
+          "flags": "i"
+        }
+      }
+    },
+    "source-qualcomm-license-headers-exist": {
       "level": "warning",
       "rule": {
         "type": "file-starts-with",
@@ -166,8 +205,7 @@
           },
           "lineCount": 60,
           "patterns": [
-            "Copyright(\\s)*(\\(c\\)|©)?",
-            "SPDX-License-Identifier|Redistribution and use in source and binary forms, with or without"
+            "(Copyright|©).*Qualcomm Innovation Center, Inc|Copyright (\\(c\\)|©) (20(1[2-9]|2[0-2])(-|,|\\s)*)+ The Linux Foundation"
           ],
           "flags": "i"
         }

--- a/repolint.json
+++ b/repolint.json
@@ -134,7 +134,7 @@
       }
     },
     "source-license-headers-exist": {
-      "level": "error",
+      "level": "warning",
       "rule": {
         "type": "file-starts-with",
         "options": {
@@ -168,45 +168,6 @@
           "patterns": [
             "Copyright(\\s)*(\\(c\\)|©)?",
             "SPDX-License-Identifier|Redistribution and use in source and binary forms, with or without"
-          ],
-          "flags": "i"
-        }
-      }
-    },
-    "source-qualcomm-license-headers-exist": {
-      "level": "warning",
-      "rule": {
-        "type": "file-starts-with",
-        "options": {
-          "globsAll": [
-            "**/*.py",
-            "**/*.js",
-            "**/*.c",
-            "**/*.cc",
-            "**/*.cpp",
-            "**/*.h",
-            "**/*.ts",
-            "**/*.sh",
-            "**/*.rs",
-            "**/*.java",
-            "**/*.go",
-            "**/*.bbclass",
-            "**/*.S",
-            "**/*.hpp"
-          ],
-          "skip-paths-matching": {
-            "patterns": [
-              "babel.config.js",
-              "build\/",
-              "jest.config.js",
-              "node_modules\/",
-              "types\/",
-              "uthash.h"
-            ]
-          },
-          "lineCount": 60,
-          "patterns": [
-            "(Copyright|©).*Qualcomm Innovation Center, Inc|Copyright (\\(c\\)|©) (20(1[2-9]|2[0-2])(-|,|\\s)*)+ The Linux Foundation"
           ],
           "flags": "i"
         }


### PR DESCRIPTION
* Make default config report only warnings if copyright/license missing
* Add new qcom config to error if qcom-based cp missing (good for onboarding new projects)

I was toying with this idea; created PR to facilitate discussion.