### PR TITLE
Don't fail if source files not found

### DIFF
--- a/repolint.json
+++ b/repolint.json
@@ -168,7 +168,8 @@
             "Copyright(\\s)*(\\(c\\)|©)?",
             "SPDX-License-Identifier|Redistribution and use in source and binary forms, with or without"
           ],
-          "flags": "i"
+          "flags": "i",
+          "succeed-on-non-existent": true
         }
       }
     },


### PR DESCRIPTION
Some projects like meta-* are mostly xml or conf files.